### PR TITLE
Run build on main*

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,10 @@
-on: [pull_request]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - 'main*'
+    tags-ignore:
+      - '**'
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g"
 jobs:


### PR DESCRIPTION
Two passing PRs caused `main` to fail. I stumbled across this and would rather be notified about it automatically.