### PR TITLE
Run build in parallel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,4 +19,4 @@ jobs:
           distribution: 'zulu'
           java-version: 11
       - uses: gradle/gradle-build-action@v2
-      - run: ./gradlew build
+      - run: ./gradlew build --parallel


### PR DESCRIPTION
Running this locally decreased the time from 5m 10s to 2m 14s. The fact that CI is taking ~25m per run is concerning, so hopefully this reduces it a decent amount.