### PR TITLE
Upgrade androidx.compose.material independently

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ stately = "1.2.3"
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
+androidx-compose-material = { module = "androidx.compose.material:material", version = "1.3.1" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version = "1.3.3" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.9.0" }
 androidx-paging-common = { module = "androidx.paging:paging-common", version.ref = "androidx-paging" }


### PR DESCRIPTION
Sharing the `androidx-compose` variable prevents Renovate from upgrading `compose.compiler`, as `compose.compiler` is on `1.4.2`, while `compose.material` is on `1.3.1`.

This PR doesn't actually do any dependency upgrading. I'll leave that to Renovate.