### PR TITLE
Rename paging-runtime to paging-runtime-uikit in docs (part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,11 @@ iOS only includes the Paging 3 APIs from AndroidX Paging.
 We don't plan on offering Paging 2 support for iOS,
 though you can continue to use Paging 2 on the JVM.
 
-### `paging-runtime-uikit`
-
-#### Android
+### `paging-runtime` for Android
 
 See the [_Interoperability with AndroidX Paging_](#interoperability-with-androidx-paging) section below.
 
-#### iOS
+### `paging-runtime-uikit` for iOS
 
 The `PagingCollectionViewController` allows a `PagingData` to be rendered via a `UICollectionView`.
 The `PagingCollectionViewController` mimics the `UICollectionViewController`,


### PR DESCRIPTION
I was a bit hasty merging #56.