### PR TITLE
Delete 3.1.1 CHANGELOG entries in 3.2.0-alpha04 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,3 @@
 # Change Log
 
 ## [Unreleased]
-
-## [3.1.1-0.2.0]
-
-### Breaking
-
-- [paging-runtime-uikit] `paging-runtime` renamed to `paging-runtime-uikit` (https://github.com/cashapp/multiplatform-paging/issues/8).
-
-### Fixed
-
-- [paging-common] Type alias `app.cash.paging.ExperimentalPagingApi` to `androidx.paging.ExperimentalPagingApi` (https://github.com/cashapp/multiplatform-paging/issues/6)
-- [paging-common] Expose RemoteMediator's public constructor (https://github.com/cashapp/multiplatform-paging/pull/46)
-
-## [3.1.1-0.1.1] - 2022-11-08
-
-### Fixed
-
-- [paging-common] Add missing iOS target
-- [paging-runtime] Add missing iOS target
-
-## [3.1.1-0.1.0] - 2022-11-08
-
-Initial release.


### PR DESCRIPTION
The `CHANGELOG` on this branch should just consist of changes in the `3.2.0-alpha04` release.