### PR TITLE
Fix duplicate class error when depending on paging-runtime-composeui and targeting Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- [paging-runtime-composeui] Fixed duplicate class error when depending on `paging-runtime-composeui` and targeting Android.
+
 ## [3.2.0-alpha04-0.2.0] - 2022-02-28
 
 ### Added

--- a/paging-runtime-composeui/build.gradle.kts
+++ b/paging-runtime-composeui/build.gradle.kts
@@ -62,7 +62,6 @@ kotlin {
     val androidMain by getting {
       dependencies {
         implementation(libs.kotlinx.coroutines.android)
-        implementation(libs.androidx.paging.compose)
       }
     }
   }


### PR DESCRIPTION
Fixes #97.