### PR TITLE
import itemKey and itemContentType from androidx

### DIFF
--- a/paging-compose-common/src/nonAndroidMain/kotlin/app/cash/paging/compose/LazyFoundationExtensions.nonAndroid.kt
+++ b/paging-compose-common/src/nonAndroidMain/kotlin/app/cash/paging/compose/LazyFoundationExtensions.nonAndroid.kt
@@ -16,6 +16,9 @@
 
 package app.cash.paging.compose
 
+import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
+
 actual fun <T : Any> LazyPagingItems<T>.itemKey(
   key: ((item: T) -> Any)?,
 ): (index: Int) -> Any = itemKey(key)


### PR DESCRIPTION
This fixes #108 the infinite recursion on calling itemKey and itemContentType 