### PR TITLE
Fix infinite recursion on calling itemKey and itemContentType in Android

### DIFF
--- a/paging-compose-common/src/androidMain/kotlin/app/cash/paging/compose/LazyFoundationExtensions.android.kt
+++ b/paging-compose-common/src/androidMain/kotlin/app/cash/paging/compose/LazyFoundationExtensions.android.kt
@@ -16,6 +16,9 @@
 
 package app.cash.paging.compose
 
+import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
+
 actual fun <T : Any> LazyPagingItems<T>.itemKey(
   key: ((item: @JvmSuppressWildcards T) -> Any)?,
 ): (index: Int) -> Any = itemKey(key)


### PR DESCRIPTION
Similar to #110.