### PR TITLE
Remove `indexCreator` constructor argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## [Unreleased]
 
+### Deprecated
+
+- [paging-runtime-uikit] Instantiating `PagingCollectionViewController` no longer requires an `indexCreator`.
+  It can be safely removed.
+
 ## [3.1.1-0.2.0]
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -57,11 +57,7 @@ Here's an example in Swift:
 ```swift
 final class FooViewController: UICollectionViewController {
 
-  private let delegate = Paging_runtime_uikitPagingCollectionViewController<Foo>(
-    indexCreator: { row, section in
-      NSIndexPath(row: Int(truncating: row), section: Int(truncating: section)) as IndexPath
-    },
-  )
+  private let delegate = Paging_runtime_uikitPagingCollectionViewController<Foo>()
 
   private let presenter = …
 

--- a/paging-runtime-uikit/src/iosMain/kotlin/app/cash/paging/PagingCollectionViewController.kt
+++ b/paging-runtime-uikit/src/iosMain/kotlin/app/cash/paging/PagingCollectionViewController.kt
@@ -11,12 +11,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import platform.Foundation.NSIndexPath
 import platform.UIKit.UICollectionView
+import platform.UIKit.indexPathForRow
 import platform.darwin.NSInteger
 
 // Making abstract causes the compilation error "Non-final Kotlin subclasses of Objective-C classes are not yet supported".
-class PagingCollectionViewController<T : Any>(
-  private val indexCreator: (row: Int, section: Int) -> NSIndexPath,
-) {
+class PagingCollectionViewController<T : Any>() {
+
+  @Deprecated(
+    "The indexCreator constructor parameter is no longer required. It can be safely removed.",
+    ReplaceWith("PagingCollectionViewController()"),
+  )
+  constructor(indexCreator: (row: Int, section: Int) -> NSIndexPath) : this()
 
   private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main
   private val workerDispatcher: CoroutineDispatcher = Dispatchers.Default
@@ -38,17 +43,17 @@ class PagingCollectionViewController<T : Any>(
     object : ListUpdateCallback {
       override fun onInserted(position: Int, count: Int) {
         checkNotNull(collectionView)
-        collectionView!!.insertItemsAtIndexPaths(List(count) { indexCreator(it + position, 0) })
+        collectionView!!.insertItemsAtIndexPaths(List(count) { NSIndexPath.indexPathForRow((it + position).toLong(), 0) })
       }
 
       override fun onRemoved(position: Int, count: Int) {
         checkNotNull(collectionView)
-        collectionView!!.deleteItemsAtIndexPaths(List(count) { indexCreator(it + position, 0) })
+        collectionView!!.deleteItemsAtIndexPaths(List(count) { NSIndexPath.indexPathForRow((it + position).toLong(), 0) })
       }
 
       override fun onMoved(fromPosition: Int, toPosition: Int) {
         checkNotNull(collectionView)
-        collectionView!!.moveItemAtIndexPath(indexCreator(fromPosition, 0), indexCreator(toPosition, 0))
+        collectionView!!.moveItemAtIndexPath(NSIndexPath.indexPathForRow(fromPosition.toLong(), 0), NSIndexPath.indexPathForRow(toPosition.toLong(), 0))
       }
 
       override fun onChanged(position: Int, count: Int, payload: Any?) {

--- a/samples/repo-search/ios-uikit/RepoSearch/RepositoriesViewController.swift
+++ b/samples/repo-search/ios-uikit/RepoSearch/RepositoriesViewController.swift
@@ -41,7 +41,7 @@ class ViewModelCollector: Kotlinx_coroutines_coreFlowCollector {
 final class RepositoriesViewController: UICollectionViewController {
   private let presenter = RepoSearchPresenter()
   
-  private let delegate = Paging_runtime_uikitPagingCollectionViewController<Repository>(indexCreator: { row, section in NSIndexPath(row: Int(truncating: row), section: Int(truncating: section)) as IndexPath})
+  private let delegate = Paging_runtime_uikitPagingCollectionViewController<Repository>()
   
   private let events = ExposedKt.mutableSharedFlow(extraBufferCapacity: Int32.max)
   


### PR DESCRIPTION
It makes the usage of `paging-runtime-uikit` a tiny bit less clunky.

I'll hold off on merging this until I'm ready to create a new release. This is purely so people aren't confused by the updated README example, as it won't compile until a new release.