### PR TITLE
Update Kotlin and stately, and add linuxArm64 target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,11 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
+  alias(libs.plugins.kotlin.multiplatform) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.spotless) apply false
+  alias(libs.plugins.android.application) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,24 @@
 [versions]
-android = "7.4.2"
+android = "8.0.2"
 androidx-activity-compose = "1.7.2"
 androidx-appcompat = "1.6.1"
 androidx-compose = "1.4.2"
 androidx-paging = "3.1.1"
-kotlin = "1.8.10"
+kotlin = "1.9.10"
 kotlinx-coroutines = "1.7.3"
-kotlinx-serialization-json = "1.5.1"
+kotlinx-serialization-json = "1.6.0"
 ktlint = "0.48.2"
-ktor = "2.3.2"
+ktor = "2.3.3"
 maven-publish = "0.25.3"
 spotless = "6.20.0"
-stately = "1.2.5"
+stately = "2.0.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
-androidx-compose-material = { module = "androidx.compose.material:material", version = "1.4.3" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui", version = "1.4.3" }
-androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.10.1" }
+androidx-compose-material = { module = "androidx.compose.material:material", version = "1.5.1" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version = "1.5.1" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.12.0" }
 androidx-paging-common = { module = "androidx.paging:paging-common", version.ref = "androidx-paging" }
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "androidx-paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version = "1.0.0-alpha20" }
@@ -33,7 +33,7 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 stately-concurrency = { module = "co.touchlab:stately-concurrency", version.ref = "stately" }
-stately-iso-collections = { module = "co.touchlab:stately-iso-collections", version.ref = "stately" }
+stately-concurrent-collections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "stately" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android" }

--- a/paging-common/build.gradle.kts
+++ b/paging-common/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
-  alias(libs.plugins.kotlin.multiplatform)
+  id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.mavenPublish)
 }
 
@@ -17,6 +17,7 @@ kotlin {
   }
   jvm()
   linuxX64()
+  linuxArm64()
   mingwX64()
 
   sourceSets {
@@ -46,7 +47,7 @@ kotlin {
       dependsOn(commonMain)
       dependencies {
         implementation(libs.stately.concurrency)
-        implementation(libs.stately.iso.collections)
+        implementation(libs.stately.concurrent.collections)
       }
     }
     val nativeMain by creating {
@@ -67,6 +68,9 @@ kotlin {
       dependsOn(nativeMain)
     }
     val linuxX64Main by getting {
+      dependsOn(nativeMain)
+    }
+    val linuxArm64Main by getting {
       dependsOn(nativeMain)
     }
     val mingwX64Main by getting {

--- a/paging-runtime-uikit/build.gradle.kts
+++ b/paging-runtime-uikit/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
-  alias(libs.plugins.kotlin.multiplatform)
+  id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.mavenPublish)
 }
 
@@ -23,7 +23,7 @@ kotlin {
         api(projects.pagingCommon)
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.stately.concurrency)
-        implementation(libs.stately.iso.collections)
+        implementation(libs.stately.concurrent.collections)
       }
     }
     val iosMain by getting {

--- a/samples/repo-search/android-composeui/build.gradle.kts
+++ b/samples/repo-search/android-composeui/build.gradle.kts
@@ -1,9 +1,10 @@
 plugins {
-  alias(libs.plugins.android.application)
-  alias(libs.plugins.kotlin.android)
+  id(libs.plugins.android.application.get().pluginId)
+  id(libs.plugins.kotlin.android.get().pluginId)
 }
 
 android {
+  namespace = "app.cash.paging.samples.reposearch"
   compileSdk = 33
 
   defaultConfig {

--- a/samples/repo-search/android-composeui/src/main/AndroidManifest.xml
+++ b/samples/repo-search/android-composeui/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  package="app.cash.paging.samples.reposearch">
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/samples/repo-search/shared/build.gradle.kts
+++ b/samples/repo-search/shared/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.kotlin.serialization)
-  alias(libs.plugins.kotlin.native.cocoapods)
+  id(libs.plugins.kotlin.multiplatform.get().pluginId)
+  id(libs.plugins.kotlin.serialization.get().pluginId)
+  id(libs.plugins.kotlin.native.cocoapods.get().pluginId)
 }
 
 kotlin {


### PR DESCRIPTION
Add `linuxArm64` support, as a [tier 2 target](https://kotlinlang.org/docs/native-target-support.html#tier-2). `co.touchlab:stately-concurrency` added `linuxArm64` support in v2.0.0, which also requires Kotlin 1.9.

I migrated the stately changes on `androidx-main-3.1.1` as well, but was unable to push the changes:
> remote: error: Trace: 8a9ace4c1c564a70221b8d76b840b8c65dc96c7ba59e45de60097a37ac6148ed
> remote: error: See https://gh.io/lfs for more information.
> remote: error: File camera/gradle/wrapper/gradle-4.6-all.zip is 101.78 MB; this exceeds GitHub's file size limit of 100.00 MB
> remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.

Could you recommend how to push this branch?

The change was just `sharedMutableListOf` to `ConcurrentMutableList`.