### PR TITLE
Remove explicit setting of properties that are the default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,3 @@
 org.gradle.parallel=true
 
-# TODO Remove when on 1.7.20 as it's the default
-kotlin.native.binary.memoryModel=experimental
-kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.mpp.stability.nowarn=true
-
 android.useAndroidX=true


### PR DESCRIPTION
- [Kotlin MPP no longer gives a warning by default](https://youtrack.jetbrains.com/issue/KT-54387)
- [New Android source set layout enabled by default](https://kotlinlang.org/docs/whatsnew19.html#new-android-source-set-layout-enabled-by-default)
- [The new Kotlin/Native memory manager enabled by default](https://kotlinlang.org/docs/whatsnew1720.html#the-new-kotlin-native-memory-manager-enabled-by-default)