### PR TITLE
Use `Scaffold` for layout in sample

### DIFF
--- a/samples/repo-search/shared-composeui/src/commonMain/kotlin/app/cash/paging/samples/reposearch/RepoSearch.kt
+++ b/samples/repo-search/shared-composeui/src/commonMain/kotlin/app/cash/paging/samples/reposearch/RepoSearch.kt
@@ -1,13 +1,11 @@
 package app.cash.paging.samples.reposearch
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Surface
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -24,28 +22,33 @@ fun RepoSearchContent(
   viewModel: ViewModel,
   events: (Event) -> Unit,
 ) {
-  Surface(Modifier.fillMaxSize()) {
-    when (viewModel) {
-      ViewModel.Empty -> {
-        Column {
+  when (viewModel) {
+    ViewModel.Empty -> {
+      Scaffold(
+        topBar = {
           SearchField(
             searchTerm = "",
             events = events,
             onRefreshList = {},
           )
-        }
-      }
-      is ViewModel.SearchResults -> {
-        val repositories = viewModel.repositories.collectAsLazyPagingItems()
-        Column {
+        },
+        content = {},
+      )
+    }
+    is ViewModel.SearchResults -> {
+      val repositories = viewModel.repositories.collectAsLazyPagingItems()
+      Scaffold(
+        topBar = {
           SearchField(
             searchTerm = viewModel.searchTerm,
             events = events,
             onRefreshList = { repositories.refresh() },
           )
+        },
+        content = {
           SearchResults(repositories)
-        }
-      }
+        },
+      )
     }
   }
 }


### PR DESCRIPTION
It's a common API that people writing Compose UI use. Much better than having some esoteric code to create a screen structure.