### PR TITLE
Use explicit native platform targets

### DIFF
--- a/paging-common/build.gradle.kts
+++ b/paging-common/build.gradle.kts
@@ -54,16 +54,19 @@ kotlin {
 
   jvm()
 
-  ios()
+  iosX64()
+  iosArm64()
   iosSimulatorArm64()
   linuxArm64()
   linuxX64()
   macosArm64()
   macosX64()
   mingwX64()
-  tvos()
+  tvosX64()
+  tvosArm64()
   tvosSimulatorArm64()
-  watchos()
+  watchosX64()
+  watchosArm64()
   watchosSimulatorArm64()
 
   sourceSets {

--- a/paging-compose-common/build.gradle.kts
+++ b/paging-compose-common/build.gradle.kts
@@ -23,15 +23,18 @@ kotlin {
 
   jvm()
 
-  ios()
+  iosX64()
+  iosArm64()
   iosSimulatorArm64()
   linuxX64()
   macosArm64()
   macosX64()
   mingwX64()
-  tvos()
+  tvosX64()
+  tvosArm64()
   tvosSimulatorArm64()
-  watchos()
+  watchosX64()
+  watchosArm64()
   watchosSimulatorArm64()
 
   sourceSets {

--- a/paging-runtime-uikit/build.gradle.kts
+++ b/paging-runtime-uikit/build.gradle.kts
@@ -13,7 +13,8 @@ plugins {
 kotlin {
   targetHierarchy.default()
 
-  ios()
+  iosX64()
+  iosArm64()
   iosSimulatorArm64()
 
   sourceSets {

--- a/paging-testing/build.gradle.kts
+++ b/paging-testing/build.gradle.kts
@@ -46,16 +46,19 @@ kotlin {
 
   jvm()
 
-  ios()
+  iosX64()
+  iosArm64()
   iosSimulatorArm64()
   linuxArm64()
   linuxX64()
   macosArm64()
   macosX64()
   mingwX64()
-  tvos()
+  tvosX64()
+  tvosArm64()
   tvosSimulatorArm64()
-  watchos()
+  watchosX64()
+  watchosArm64()
   watchosSimulatorArm64()
 
   sourceSets {


### PR DESCRIPTION
The shorthand ones are deprecated in 1.9.2x