### PR TITLE
Reduce `./gradlew build` noise when not running on macOS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+kotlin.native.ignoreDisabledTargets=true
+
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true
 


### PR DESCRIPTION
I'm on Linux now and I don't want to be constantly berated for it by`./gradlew build`.